### PR TITLE
Fixed out of memory issue using InputStream and

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ buildNumber.properties
 .classpath
 .externalToolBuilders/
 .settings/
+
+#IntelliJ
+.idea
+risecache.iml

--- a/src/main/java/com/risevision/risecache/server/Worker.java
+++ b/src/main/java/com/risevision/risecache/server/Worker.java
@@ -76,34 +76,6 @@ class Worker extends WebServer implements HttpConstants, Runnable {
 		}
 	}
 
-	  /**
-	   * @return the given string with any %20 sequences decoded
-	   */
-/*	  private String decodeWebChars(String line) {
-	    // GET /dart/test%C3%BCuuuu/swipe.html HTTP/1.1
-	    //   ==>
-	    // GET /dart/test�uuuu/swipe.html HTTP/1.1
-
-	    byte[] bytes = line.getBytes();
-	    ByteArrayOutputStream out = new ByteArrayOutputStream();
-
-	    for (int i = 0; i < bytes.length; i++) {
-	      if (bytes[i] == '%' && (i + 2 < bytes.length)) {
-	        int val = hex2Int((char) bytes[i + 1], (char) bytes[i + 2]);
-
-	        out.write(val);
-
-	        i += 2;
-	      } else {
-	        out.write(bytes[i]);
-	      }
-	    }
-
-	    return new String(out.toByteArray(), StandardCharsets.UTF_8);
-	    
-	  }*/
-	  
-
 	  private HttpHeader parseHeader(InputStream inputStream) throws IOException {
 	    HttpHeader header = new HttpHeader();
 	    


### PR DESCRIPTION
OutputStream classes for reading and writing the
file content

Used BufferedInputStream with a buffer of 15MB so videos don't get chopped and play smoothly.

Trello card here: https://trello.com/c/4Nz1Dkrk/1091-5-resolve-rise-cache-heap-issues
Jar for testing here: https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/RiseCache/RiseCache_v3.jar

@tejohnso @fjvallarino please review.

cheers