### PR TITLE
Added User-Agent to headers of the request

### DIFF
--- a/src/main/java/com/risevision/risecache/downloader/DownloadManager.java
+++ b/src/main/java/com/risevision/risecache/downloader/DownloadManager.java
@@ -67,7 +67,9 @@ public class DownloadManager {
 			} else {
 				connection = (HttpURLConnection) url.openConnection();
 			}
-			
+
+			connection.setRequestProperty("User-Agent", "Mozilla/5.0 (X11; CrOS x86_64 7520.67.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.110 Safari/537.36");
+
 			if (!isGetRequest)
 				connection.setRequestMethod("HEAD");
 


### PR DESCRIPTION
When requesting to download a file some servers require a user-agent on the header.

@tejohnso @fjvallarino this is a fix for https://github.com/Rise-Vision/rise-cache/issues/9. Please review.

Cheers 